### PR TITLE
Fix remotes

### DIFF
--- a/debian/README.debian
+++ b/debian/README.debian
@@ -21,7 +21,7 @@ How to build the package
 ------------------------
 
     git checkout ubuntu/trusty
-    gbp buildpackage --git-dist=trusty --git-debian-branch=ubuntu/trusty
+    gbp buildpackage --git-dist=trusty --git-debian-branch=ubuntu/trusty --git-upstream-tree=branch
 
 Add --git-pbuilder, -us -uc, etc. as necessary for your local workflow.
 
@@ -42,11 +42,11 @@ How to update when upstream changes
 2. Rebase the patch queue branch off of upstream, updating the
    patches as necessary:
 
-    gbp-pq switch
+    gbp pq switch
     git rebase upstream
 
 3. Refresh the quilt patches:
 
-    gbp-pq switch
-    gbp-pq export
+    gbp pq switch
+    gbp pq export
     git commit -a 'Refresh quilt patches'

--- a/debian/patches/0003-Fix-bad-itertools.zip-call.patch
+++ b/debian/patches/0003-Fix-bad-itertools.zip-call.patch
@@ -1,26 +1,13 @@
 From: Neil Williams <neil@reddit.com>
 Date: Wed, 28 Oct 2015 00:08:06 -0700
-Subject: Python: Make remote Python 3 compatible.
+Subject: Fix bad itertools.zip call
 
-These modules didn't import/run properly on Py3.
+itertools.zip does not exist. We'll just stomach the slight inefficency
+in Python 2 since it really doesn't matter.
 ---
- thrift/lib/py/util/randomizer.py | 2 +-
- thrift/lib/py/util/remote.py     | 3 +--
- 2 files changed, 2 insertions(+), 3 deletions(-)
+ thrift/lib/py/util/remote.py | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
 
-diff --git a/thrift/lib/py/util/randomizer.py b/thrift/lib/py/util/randomizer.py
-index 16dd1cd..02f1afc 100644
---- a/thrift/lib/py/util/randomizer.py
-+++ b/thrift/lib/py/util/randomizer.py
-@@ -387,7 +387,7 @@ def _integer_randomizer_factory(name, ttype, n_bits):
-             else:
-                 raise TypeError("Invalid %s seed: %s" % (_name, seed))
- 
--    NBitIntegerRandomizer.__name__ = six.binary_type("%sRandomizer" % _name)
-+    NBitIntegerRandomizer.__name__ = "%sRandomizer" % _name
- 
-     return NBitIntegerRandomizer
- 
 diff --git a/thrift/lib/py/util/remote.py b/thrift/lib/py/util/remote.py
 index 6296523..d249d62 100644
 --- a/thrift/lib/py/util/remote.py

--- a/debian/patches/0005-Fix-Python-3-compatibility-of-fuzzer-code.patch
+++ b/debian/patches/0005-Fix-Python-3-compatibility-of-fuzzer-code.patch
@@ -1,0 +1,25 @@
+From: Neil Williams <neil@reddit.com>
+Date: Tue, 9 May 2017 23:35:39 -0700
+Subject: Fix Python 3 compatibility of fuzzer code
+
+For __name__, Python 2 wants str and Python 3 wants unicode. Fun.
+---
+ thrift/lib/py/util/randomizer.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/thrift/lib/py/util/randomizer.py b/thrift/lib/py/util/randomizer.py
+index 16dd1cd..cd10671 100644
+--- a/thrift/lib/py/util/randomizer.py
++++ b/thrift/lib/py/util/randomizer.py
+@@ -387,7 +387,10 @@ def _integer_randomizer_factory(name, ttype, n_bits):
+             else:
+                 raise TypeError("Invalid %s seed: %s" % (_name, seed))
+ 
+-    NBitIntegerRandomizer.__name__ = six.binary_type("%sRandomizer" % _name)
++    if six.PY2:
++        NBitIntegerRandomizer.__name__ = str("%sRandomizer" % _name)
++    else:
++        NBitIntegerRandomizer.__name__ = "%sRandomizer" % _name
+ 
+     return NBitIntegerRandomizer
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,5 @@
 0001-Build-only-the-compiler.patch
 0002-Python-Make-remotes-work-without-PAR.patch
-0003-Python-Make-remote-Python-3-compatible.patch
+0003-Fix-bad-itertools.zip-call.patch
 0004-Add-event-for-handler-completion.patch
+0005-Fix-Python-3-compatibility-of-fuzzer-code.patch


### PR DESCRIPTION
It's useful to have the ability to run a very simple thrift client from the CLI when devving a service. Thrift comes with tooling for this built in, but it was broken on Python 3. When originally packaging this I tried to fix it on Python 3 and broke it on Py2 in the process. This makes it so we can use the remote tool from both versions of the language. There's a bit more churn in this diff than reality, just because of splitting up stuff properly and what that means to quilt. Here's the operative diff from before to after in the actual output packaged code:

```diff
diff --git a/thrift/lib/py/util/randomizer.py b/thrift/lib/py/util/randomizer.py
index 02f1afc..cd10671 100644
--- a/thrift/lib/py/util/randomizer.py
+++ b/thrift/lib/py/util/randomizer.py
@@ -387,7 +387,10 @@ def _integer_randomizer_factory(name, ttype, n_bits):
             else:
                 raise TypeError("Invalid %s seed: %s" % (_name, seed))
 
-    NBitIntegerRandomizer.__name__ = "%sRandomizer" % _name
+    if six.PY2:
+        NBitIntegerRandomizer.__name__ = str("%sRandomizer" % _name)
+    else:
+        NBitIntegerRandomizer.__name__ = "%sRandomizer" % _name
 
     return NBitIntegerRandomizer

```

tl;dr is that `from __future__ import unicode_literals` is on, so in both Py2 and Py3 `"blah"` is unicode. Py3 is cool with unicode being assigned to a class's `__name__` (and in fact requires that it not be `bytes`) but Py2 is not.

I also took the opportunity to fix some issues in the README.

Once this is done, I'll add docs to the cookiecutter on how to use the remote. It looks something like this:

```
ubuntu@activity:~/src/activity$ python -m activity.activity_thrift.remote
Usage: remote.py [OPTIONS] FUNCTION [ARGS ...]

Options:

-c --compact         Use TCompactProtocol
-f --framed          Use framed transport
-h HOST[:PORT], --host HOST[:PORT] The host and port to connect to
-j --json            Use TJSONProtocol
-s --ssl             Use SSL socket
-U --unframed        Use unframed transport
-F --fuzz            Use TFuzzyHeaderTransport to send a fuzzed message for testing thrift transport. Optionally include a list of message field names to fuzz after this flag. Fields: magic, seq_id, proto_id, num_transforms, padding, length, version, flags, header_size, transform_id, padding_bytes, payload, identity
-u --url             The URL to connect to, for HTTP transport

ubuntu@activity:~/src/activity$ python -m activity.activity_thrift.remote -h localhost:9090 count_activity some_context
ActivityInfo(
    count=0,
    is_fuzzed=True)
```