### PR TITLE
This fixes the unicode character issue we were having

### DIFF
--- a/thrift/lib/py/protocol/TJSONProtocol.py
+++ b/thrift/lib/py/protocol/TJSONProtocol.py
@@ -40,8 +40,18 @@ BACKSLASH = '\\'
 ZERO = '0'
 
 ESCSEQ = '\\u00'
+ESCSEQ0 = ord('\\')
+ESCSEQ1 = ord('u')
 ESCAPE_CHAR = '"\\bfnrt'
-ESCAPE_CHAR_VALS = ['"', '\\', '\b', '\f', '\n', '\r', '\t']
+ESCAPE_CHAR_VALS = {
+    '"': '\\"',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t',
+}
 NUMERIC_CHAR = '+-.0123456789Ee'
 
 CTYPES = {TType.BOOL:       'tf',
@@ -208,7 +218,30 @@ class TJSONProtocolBase(TProtocolBase):
             raise TProtocolException(TProtocolException.INVALID_DATA,
                                      "Unexpected character: %s" % current)
 
+    def _isHighSurrogate(self, codeunit):
+        return codeunit >= 0xd800 and codeunit <= 0xdbff
+
+    def _isLowSurrogate(self, codeunit):
+        return codeunit >= 0xdc00 and codeunit <= 0xdfff
+
+    def _toChar(self, high, low=None):
+        if not low:
+            if sys.version_info[0] == 2:
+                return ("\\u%04x" % high).decode('unicode-escape') \
+                                         .encode('utf-8')
+            else:
+                return chr(high)
+        else:
+            codepoint = (1 << 16) + ((high & 0x3ff) << 10)
+            codepoint += low & 0x3ff
+            if sys.version_info[0] == 2:
+                s = "\\U%08x" % codepoint
+                return s.decode('unicode-escape').encode('utf-8')
+            else:
+                return chr(codepoint)
+
     def readJSONString(self, skipContext):
+        highSurrogate = None
         string = []
         if skipContext is False:
             self.context.read()
@@ -217,27 +250,48 @@ class TJSONProtocolBase(TProtocolBase):
             character = self.reader.read()
             if character == QUOTE:
                 break
-            if character == ESCSEQ[0]:
+            if ord(character) == ESCSEQ0:
                 character = self.reader.read()
-                if character == ESCSEQ[1]:
-                    self.readJSONSyntaxChar(ZERO)
-                    self.readJSONSyntaxChar(ZERO)
-                    data = self.trans.read(2)
-                    if sys.version_info[0] >= 3 and isinstance(data, bytes):
-                        character = json.JSONDecoder().decode(
-                                '"\\u00%s"' % str(data, 'utf-8'))
-                    else:
-                        character = json.JSONDecoder().decode('"\\u00%s"' %
-                                data)
-                else:
-                    off = ESCAPE_CHAR.find(character)
-                    if off == -1:
-                        raise TProtocolException(
+                if ord(character) == ESCSEQ1:
+                    character = self.trans.read(4).decode('ascii')
+                    codeunit = int(character, 16)
+                    if self._isHighSurrogate(codeunit):
+                        if highSurrogate:
+                            raise TProtocolException(
                                 TProtocolException.INVALID_DATA,
-                                "Expected control char")
-                    character = ESCAPE_CHAR_VALS[off]
+                                "Expected low surrogate char")
+                        highSurrogate = codeunit
+                        continue
+                    elif self._isLowSurrogate(codeunit):
+                        if not highSurrogate:
+                            raise TProtocolException(
+                                TProtocolException.INVALID_DATA,
+                                "Expected high surrogate char")
+                        character = self._toChar(highSurrogate, codeunit)
+                        highSurrogate = None
+                    else:
+                        character = self._toChar(codeunit)
+                else:
+                    if character not in ESCAPE_CHARS:
+                        raise TProtocolException(
+                            TProtocolException.INVALID_DATA,
+                            "Expected control char")
+                    character = ESCAPE_CHARS[character]
+            elif character in ESCAPE_CHAR_VALS:
+                raise TProtocolException(TProtocolException.INVALID_DATA,
+                                         "Unescaped control char")
+            elif sys.version_info[0] > 2:
+                utf8_bytes = bytearray([ord(character)])
+                while ord(self.reader.peek()) >= 0x80:
+                    utf8_bytes.append(ord(self.reader.read()))
+                character = utf8_bytes.decode('utf8')
             string.append(character)
-        return ''.join(string)
+
+            if highSurrogate:
+                raise TProtocolException(TProtocolException.INVALID_DATA,
+                                         "Expected low surrogate char")
+        newstring = (b''.join(str(ch) for ch in string))
+        return newstring
 
     def isJSONNumeric(self, character):
         return (True if NUMERIC_CHAR.find(character) != - 1 else False)


### PR DESCRIPTION
At the moment multibyte unicode characters cause the following error in the eventcollector when using the JSONProtocol:
'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)

This causes events to be dropped and puts any baseplate publishers that are attempting to send such events into an infinite 400 loop.

Example:
In the redesign go to r/emojipasta and trigger a screenview on a post with unicode characters such as smiley emojis such as https://www.reddit.com/r/emojipasta/comments/7bff8v/click_here_to_join_our_new_discord/
OR Create a comment "testytest ‣ test" with the new V2 comment events in https://github.com/reddit/reddit-public/pull/8474

In Kafka you won't see these events.

However with this change copied into the staging eventcollectors in /usr/lib/python2.7/dist-packages/thrift/protocol/TJSONProtocol.py the multibyte character correctly gets encoded by the event collector and put into Kafka:

proof:

{"comment": {"post_id": "t3_o", "author_id": "t2_1", "id": "t1_m0", "body_text": "**testytest \u2023 test**"}, "noun": "comment", "uuid": "89347680-cef3-49c5-bba6-c56988535254", "referrer": {"url": "https://reddit.local/r/pics/comments/o/my_wife_put_up_in_the_sierra_nevada_after_using/", "domain": "reddit.local", "element": ""}, "request": {"domain": "reddit.local", "client_ip": "4.7.12.50", "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Safari/537.36"}, "subreddit": {"id": "t5_1m", "name": "pics"}, "client_timestamp": 1513728823183, "source": "backend", "user": {"created_timestamp": 1508434790494, "logged_in": true, "id": "t2_1"}, "action": "submit", "endpoint_timestamp": 1513728823000, "post": {"spoiler": false, "domain": "i.redd.it", "title": "My wife put up in the Sierra Nevada after using an Ancient Monastery look", "url": "https://i.redd.it/xl8cnd8ohs401.jpg", "body_text": "", "promoted": false, "nsfw": false, "created_timestamp": 1513709315978, "author_id": "t2_16", "type": "link", "id": "t3_o"}}

This solution was found by merging in code from https://github.com/apache/thrift/blob/master/lib/py/src/protocol/TJSONProtocol.py (the original thrift lib) that seemed to better handle escape characters and also applying a different way of collapsing the list of characters into a string.